### PR TITLE
Fix for JwtMiddleware serialization

### DIFF
--- a/src/Authentication/JWT/JwtMiddleware.cs
+++ b/src/Authentication/JWT/JwtMiddleware.cs
@@ -86,7 +86,7 @@ namespace EMG.Extensions.AspNetCore
 
     public class TokenModel
     {
-        [JsonProperty("accessToken")]
+        [JsonProperty("access_token")]
         public string AccessToken { get; set; }
 
         [JsonProperty("expires_in")]

--- a/tests/Authentication/Tests.Jwt.Web/AuthenticationTests.cs
+++ b/tests/Authentication/Tests.Jwt.Web/AuthenticationTests.cs
@@ -45,7 +45,7 @@ namespace Tests
 
                     var obj = JObject.Parse(body);
 
-                    token = obj["accessToken"].Value<string>();
+                    token = obj["access_token"].Value<string>();
                 }
             }
 


### PR DESCRIPTION
Updated the JwtMiddleware JsonProperty for access token in the Token model to be consistent and match the client package


@Kralizek 