### PR TITLE
COREX-1392 migrate static images - Update package icon

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/emgdev/aspnetcore-extensions</PackageProjectUrl>
-    <PackageIconUrl>http://static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn-static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
     <NoWarn>NU5105,NU5125</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Moved package icon to emg-static bucket (see ticket https://keystoneedugroup.atlassian.net/browse/COREX-1392?focusedCommentId=146880)